### PR TITLE
Changed min padding to -18

### DIFF
--- a/BlizzHUDTweaks/Options/Miscellaneous.lua
+++ b/BlizzHUDTweaks/Options/Miscellaneous.lua
@@ -456,7 +456,7 @@ local function addActionbarPaddingOption(profile, t, option, order)
         name = "Padding",
         desc = option.description or "",
         type = "range",
-        min = -4,
+        min = -18,
         max = 18,
         step = 1,
         set = function(info, value)


### PR DESCRIPTION
I wanted to shove my action bar buttons right up against each other and wasn't able to do so with just the minimum setting at -4. Dominos and Bartender4 both allow for this, but I prefer this add-on. Suggesting this change.